### PR TITLE
Allow to use a simple string to run a command

### DIFF
--- a/chain.py
+++ b/chain.py
@@ -5,6 +5,10 @@ class ChainCommand(sublime_plugin.WindowCommand):
     def run(self, commands):
         window = self.window
         for command in commands:
-            command_name = command[0]
-            command_args = command[1:]
+            if isinstance(command, str):
+                command_name = command
+                command_args = []
+            else:
+                command_name = command[0]
+                command_args = command[1:]
             window.run_command(command_name, *command_args)


### PR DESCRIPTION
Hey!

Thanks for your plugin, it's really useful.

But, I thought about something that could be improved. 

If the command is a string instead of a list, it consider that it doesn't have any args (just like if it was a list with only the command name in it). 

Matt